### PR TITLE
Refactor to ES6 classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 sandbox.js
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ sudo: true
 node_js:
   - 10
   - 12
+  - 14

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+sudo: true
+node_js:
+  - 10
+  - 12

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Small module that helps you maintain state around resources
 npm install nanoresource
 ```
 
+[![Build Status](https://travis-ci.org/mafintosh/nanoresource.svg?branch=master)](https://travis-ci.org/mafintosh/nanoresource)
+
 Allows you to easily implement open/close functionality for a resource
 and having a way to mark the resource as active/inactive to avoid it being closed
 while it is in middle of something.

--- a/emitter.js
+++ b/emitter.js
@@ -1,142 +1,63 @@
-// Copy of index.js that extends from EventEmitter
+const { EventEmitter } = require('events')
+const nanoresource = require('.')
 
-const events = require('events')
-const inherits = require('inherits')
+const kNanoresource = Symbol('nanosignal.nanoresource')
 
-const opening = Symbol('opening queue')
-const preclosing = Symbol('closing when inactive')
-const closing = Symbol('closing queue')
-const sync = Symbol('sync')
-const fastClose = Symbol('fast close')
+class Nanoresource extends EventEmitter {
+  constructor (opts = {}) {
+    super()
 
-module.exports = Nanoresource
-
-function Nanoresource (opts) {
-  if (!(this instanceof Nanoresource)) return new Nanoresource(opts)
-  events.EventEmitter.call(this)
-
-  if (!opts) opts = {}
-  if (opts.open) this._open = opts.open
-  if (opts.close) this._close = opts.close
-
-  this.opening = false
-  this.opened = false
-  this.closing = false
-  this.closed = false
-  this.actives = 0
-
-  this[opening] = null
-  this[preclosing] = null
-  this[closing] = null
-  this[sync] = false
-  this[fastClose] = true
-}
-
-inherits(Nanoresource, events.EventEmitter)
-
-Nanoresource.prototype._open = function (cb) {
-  cb(null)
-}
-
-Nanoresource.prototype._close = function (cb) {
-  cb(null)
-}
-
-Nanoresource.prototype.open = function (cb) {
-  if (!cb) cb = noop
-
-  if (this[closing] || this.closed) return process.nextTick(cb, new Error('Resource is closed'))
-  if (this.opened) return process.nextTick(cb)
-
-  if (this[opening]) {
-    this[opening].push(cb)
-    return
+    this[kNanoresource] = nanoresource({
+      open: opts.open || this._open.bind(this),
+      close: opts.close || this._close.bind(this),
+      reopen: opts.reopen
+    })
   }
 
-  this.opening = true
-  this[opening] = [cb]
-  this[sync] = true
-  this._open(onopen.bind(this))
-  this[sync] = false
-}
-
-Nanoresource.prototype.active = function (cb) {
-  if ((this[fastClose] && this[preclosing]) || this[closing] || this.closed) {
-    if (cb) process.nextTick(cb, new Error('Resource is closed'))
-    return false
-  }
-  this.actives++
-  return true
-}
-
-Nanoresource.prototype.inactive = function (cb, err, val) {
-  if (!--this.actives) {
-    const queue = this[preclosing]
-    if (queue) {
-      this[preclosing] = null
-      while (queue.length) this.close(queue.shift())
-    }
+  get opening () {
+    return this[kNanoresource].opening
   }
 
-  if (cb) cb(err, val)
-}
-
-Nanoresource.prototype.close = function (allowActive, cb) {
-  if (typeof allowActive === 'function') return this.close(false, allowActive)
-  if (!cb) cb = noop
-
-  if (allowActive) this[fastClose] = false
-
-  if (this.closed) return process.nextTick(cb)
-
-  if (this.actives || this[opening]) {
-    if (!this[preclosing]) this[preclosing] = []
-    this[preclosing].push(cb)
-    return
+  get opened () {
+    return this[kNanoresource].opened
   }
 
-  if (!this.opened) {
-    this.closed = true
-    process.nextTick(cb)
-    return
+  get closing () {
+    return this[kNanoresource].closing
   }
 
-  if (this[closing]) {
-    this[closing].push(cb)
-    return
+  get closed () {
+    return this[kNanoresource].closed
   }
 
-  this.closing = true
-  this[closing] = [cb]
-  this[sync] = true
-  this._close(onclose.bind(this))
-  this[sync] = false
-}
+  get actives () {
+    return this[kNanoresource].actives
+  }
 
-function onopen (err) {
-  if (this[sync]) return process.nextTick(onopen.bind(this), err)
+  open (cb) {
+    this[kNanoresource].open(cb)
+  }
 
-  const oqueue = this[opening]
-  this[opening] = null
-  this.opening = false
-  this.opened = !err
+  close (allowActive, cb) {
+    this[kNanoresource].close(allowActive, cb)
+  }
 
-  while (oqueue.length) oqueue.shift()(err)
+  active (cb) {
+    return this[kNanoresource].active(cb)
+  }
 
-  const cqueue = this[preclosing]
-  if (cqueue && !this.actives) {
-    this[preclosing] = null
-    while (cqueue.length) this.close(cqueue.shift())
+  inactive (cb, err, val) {
+    this[kNanoresource].inactive(cb, err, val)
+  }
+
+  _open (cb) {
+    cb(null)
+  }
+
+  _close (cb) {
+    cb(null)
   }
 }
 
-function onclose (err) {
-  if (this[sync]) return process.nextTick(onclose.bind(this), err)
-  const queue = this[closing]
-  this.closing = false
-  this[closing] = null
-  this.closed = !err
-  while (queue.length) queue.shift()(err)
-}
-
-function noop () {}
+module.exports = (opts) => new Nanoresource(opts)
+module.exports.Nanoresource = Nanoresource

--- a/index.js
+++ b/index.js
@@ -148,11 +148,6 @@ function onclose (err) {
   this.closing = false
   this[closing] = null
   this.closed = !err
-
-  if (this.closed) {
-    this.opened = false
-  }
-
   while (queue.length) queue.shift()(err)
 
   const cqueue = this[preopening]

--- a/index.js
+++ b/index.js
@@ -148,6 +148,11 @@ function onclose (err) {
   this.closing = false
   this[closing] = null
   this.closed = !err
+
+  if (this.closed) {
+    this.opened = false
+  }
+
   while (queue.length) queue.shift()(err)
 
   const cqueue = this[preopening]

--- a/index.js
+++ b/index.js
@@ -1,108 +1,128 @@
+const preopening = Symbol('opening when closing')
 const opening = Symbol('opening queue')
 const preclosing = Symbol('closing when inactive')
 const closing = Symbol('closing queue')
 const sync = Symbol('sync')
 const fastClose = Symbol('fast close')
+const reopen = Symbol('allow reopen')
+const init = Symbol('init state')
 
-module.exports = Nanoresource
+class Nanoresource {
+  constructor (opts) {
+    if (!opts) opts = {}
+    if (opts.open) this._open = opts.open
+    if (opts.close) this._close = opts.close
 
-function Nanoresource (opts) {
-  if (!(this instanceof Nanoresource)) return new Nanoresource(opts)
+    this[init]()
 
-  if (!opts) opts = {}
-  if (opts.open) this._open = opts.open
-  if (opts.close) this._close = opts.close
-
-  this.opening = false
-  this.opened = false
-  this.closing = false
-  this.closed = false
-  this.actives = 0
-
-  this[opening] = null
-  this[preclosing] = null
-  this[closing] = null
-  this[sync] = false
-  this[fastClose] = true
-}
-
-Nanoresource.prototype._open = function (cb) {
-  cb(null)
-}
-
-Nanoresource.prototype._close = function (cb) {
-  cb(null)
-}
-
-Nanoresource.prototype.open = function (cb) {
-  if (!cb) cb = noop
-
-  if (this[closing] || this.closed) return process.nextTick(cb, new Error('Resource is closed'))
-  if (this.opened) return process.nextTick(cb)
-
-  if (this[opening]) {
-    this[opening].push(cb)
-    return
+    this[reopen] = opts.reopen || false
+    this[preopening] = null
+    this[opening] = null
+    this[preclosing] = null
+    this[closing] = null
+    this[sync] = false
+    this[fastClose] = true
   }
 
-  this.opening = true
-  this[opening] = [cb]
-  this[sync] = true
-  this._open(onopen.bind(this))
-  this[sync] = false
-}
-
-Nanoresource.prototype.active = function (cb) {
-  if ((this[fastClose] && this[preclosing]) || this[closing] || this.closed) {
-    if (cb) process.nextTick(cb, new Error('Resource is closed'))
-    return false
+  [init] () {
+    this.opening = false
+    this.opened = false
+    this.closing = false
+    this.closed = false
+    this.actives = 0
   }
-  this.actives++
-  return true
-}
 
-Nanoresource.prototype.inactive = function (cb, err, val) {
-  if (!--this.actives) {
-    const queue = this[preclosing]
-    if (queue) {
-      this[preclosing] = null
-      while (queue.length) this.close(queue.shift())
+  _open (cb) {
+    cb(null)
+  }
+
+  _close (cb) {
+    cb(null)
+  }
+
+  open (cb) {
+    if (!cb) cb = noop
+
+    if (this.closing || this.closed) {
+      if (!this[reopen]) {
+        return process.nextTick(cb, new Error('Resource is closed'))
+      }
+
+      if (this.closing) {
+        if (!this[preopening]) this[preopening] = []
+        this[preopening].push(cb)
+        return
+      }
+
+      this[init]()
     }
+
+    if (this.opened) return process.nextTick(cb)
+
+    if (this[opening]) {
+      this[opening].push(cb)
+      return
+    }
+
+    this.opening = true
+    this[opening] = [cb]
+    this[sync] = true
+    this._open(onopen.bind(this))
+    this[sync] = false
   }
 
-  if (cb) cb(err, val)
-}
-
-Nanoresource.prototype.close = function (allowActive, cb) {
-  if (typeof allowActive === 'function') return this.close(false, allowActive)
-  if (!cb) cb = noop
-
-  if (allowActive) this[fastClose] = false
-
-  if (this.closed) return process.nextTick(cb)
-
-  if (this.actives || this[opening]) {
-    if (!this[preclosing]) this[preclosing] = []
-    this[preclosing].push(cb)
-    return
+  active (cb) {
+    if ((this[fastClose] && this[preclosing]) || this[closing] || this.closed) {
+      if (cb) process.nextTick(cb, new Error('Resource is closed'))
+      return false
+    }
+    this.actives++
+    return true
   }
 
-  if (!this.opened) {
-    this.closed = true
-    process.nextTick(cb)
-    return
+  inactive (cb, err, val) {
+    if (!--this.actives) {
+      const queue = this[preclosing]
+      if (queue) {
+        this[preclosing] = null
+        while (queue.length) this.close(queue.shift())
+      }
+    }
+
+    if (cb) cb(err, val)
   }
 
-  if (this[closing]) {
-    this[closing].push(cb)
-    return
-  }
+  close (allowActive, cb) {
+    if (typeof allowActive === 'function') return this.close(false, allowActive)
+    if (!cb) cb = noop
 
-  this.closing = true
-  this[closing] = [cb]
-  this[sync] = true
-  this._close(onclose.bind(this))
-  this[sync] = false
+    if (allowActive) this[fastClose] = false
+
+    if (this.closed) return process.nextTick(cb)
+
+    if (this.actives || this[opening]) {
+      if (!this[preclosing]) this[preclosing] = []
+      this[preclosing].push(cb)
+      return
+    }
+
+    if (!this.opened) {
+      this.closed = true
+      process.nextTick(cb)
+      return
+    }
+
+    if (this[closing]) {
+      this[closing].push(cb)
+      return
+    }
+
+    this.closing = true
+    this[closing] = [cb]
+    this[sync] = true
+    this._close(onclose.bind(this))
+    this[sync] = false
+  }
 }
 
 function onopen (err) {
@@ -129,6 +149,15 @@ function onclose (err) {
   this[closing] = null
   this.closed = !err
   while (queue.length) queue.shift()(err)
+
+  const cqueue = this[preopening]
+  if (cqueue) {
+    this[preopening] = null
+    while (cqueue.length) this.open(cqueue.shift())
+  }
 }
 
 function noop () {}
+
+module.exports = (opts) => new Nanoresource(opts)
+module.exports.Nanoresource = Nanoresource

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "description": "Small module that helps you maintain state around resources",
   "main": "index.js",
   "scripts": {
-    "test": "standard && tape test/*.js"
+    "test": "tape test/*.js",
+    "posttest": "standard"
   },
   "author": "Mathias Buus (@mafintosh)",
   "license": "MIT",
   "devDependencies": {
-    "standard": "^14.3.1",
-    "tape": "^4.11.0"
+    "standard": "^14.3.4",
+    "tape": "^4.13.2"
   },
   "repository": {
     "type": "git",

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,116 +1,166 @@
 const tape = require('tape')
 const nanoresource = require('../')
+const nanoresourceEmitter = require('../emitter')
 
-tape('basic usage', function (t) {
-  t.plan(2 + 2 + 3 * 3 + 3 * 3)
+function test (title, createNanoresource) {
+  tape(title + ' basic usage', function (t) {
+    t.plan(2 + 2 + 3 * 3 + 3 * 3)
 
-  let opened = false
-  let closed = false
+    let opened = false
+    let closed = false
 
-  const r = nanoresource({
-    open (cb) {
-      t.notOk(closed, 'not closed in open')
-      t.notOk(opened, 'only open once')
-      opened = true
-      cb(null)
-    },
-    close (cb) {
-      t.ok(opened, 'opened when closing')
-      t.notOk(closed, 'only close once')
-      closed = true
-      cb(null)
-    }
-  })
-
-  r.open(onopen)
-  r.open(onopen)
-  r.open(onopen)
-
-  r.close(onclose)
-  r.close(onclose)
-  r.close(onclose)
-
-  function onopen (err) {
-    t.error(err, 'no error')
-    t.ok(r.opened, 'was opened')
-    t.ok(opened, 'open ran')
-  }
-
-  function onclose (err) {
-    t.error(err, 'no error')
-    t.ok(r.closed, 'was closed')
-    t.ok(closed, 'close ran')
-  }
-})
-
-tape('open/close is never sync', function (t) {
-  const r = nanoresource({
-    open (cb) {
-      cb(null)
-    },
-    close (cb) {
-      cb(null)
-    }
-  })
-
-  let syncOpen = true
-  r.open(function () {
-    t.notOk(syncOpen)
-    let syncClose = true
-    r.close(function () {
-      t.notOk(syncClose)
-      t.end()
+    const r = createNanoresource({
+      open (cb) {
+        t.notOk(closed, 'not closed in open')
+        t.notOk(opened, 'only open once')
+        opened = true
+        cb(null)
+      },
+      close (cb) {
+        t.ok(opened, 'opened when closing')
+        t.notOk(closed, 'only close once')
+        closed = true
+        cb(null)
+      }
     })
-    syncClose = false
-  })
-  syncOpen = false
-})
 
-tape('active/inactive', function (t) {
-  t.plan(2 + 10 * 1)
+    r.open(onopen)
+    r.open(onopen)
+    r.open(onopen)
 
-  let fails = 0
-  let ran = 0
+    r.close(onclose)
+    r.close(onclose)
+    r.close(onclose)
 
-  const r = nanoresource({
-    close (cb) {
-      t.same(fails, 0)
-      t.same(ran, 10)
-      cb(null)
+    function onopen (err) {
+      t.error(err, 'no error')
+      t.ok(r.opened, 'was opened')
+      t.ok(opened, 'open ran')
+    }
+
+    function onclose (err) {
+      t.error(err, 'no error')
+      t.ok(r.closed, 'was closed')
+      t.ok(closed, 'close ran')
     }
   })
 
-  for (let i = 0; i < 10; i++) {
+  tape(title + ' open/close is never sync', function (t) {
+    const r = createNanoresource({
+      open (cb) {
+        cb(null)
+      },
+      close (cb) {
+        cb(null)
+      }
+    })
+
+    let syncOpen = true
     r.open(function () {
-      t.ok(r.active())
-      ran++
-      fails++
-      setImmediate(function () {
-        fails--
-        r.inactive()
+      t.notOk(syncOpen)
+      let syncClose = true
+      r.close(function () {
+        t.notOk(syncClose)
+        t.end()
       })
+      syncClose = false
     })
-  }
-
-  r.open(() => r.close())
-})
-
-tape('active after close', function (t) {
-  t.plan(5)
-
-  const r = nanoresource({
-    close (cb) {
-      t.notOk(r.active(), 'cannot be active in close')
-      setImmediate(cb)
-    }
+    syncOpen = false
   })
 
-  t.ok(r.active(), 'can be active')
-  r.open()
-  t.ok(r.active(), 'can be active')
-  r.close(() => t.notOk(r.active(), 'still cannot be active'))
-  t.notOk(r.active(), 'cannot be active cause close was call')
+  tape(title + ' active/inactive', function (t) {
+    t.plan(2 + 10 * 1)
 
-  r.inactive()
-  r.inactive()
-})
+    let fails = 0
+    let ran = 0
+
+    const r = createNanoresource({
+      close (cb) {
+        t.same(fails, 0)
+        t.same(ran, 10)
+        cb(null)
+      }
+    })
+
+    for (let i = 0; i < 10; i++) {
+      r.open(function () {
+        t.ok(r.active())
+        ran++
+        fails++
+        setImmediate(function () {
+          fails--
+          r.inactive()
+        })
+      })
+    }
+
+    r.open(() => r.close())
+  })
+
+  tape(title + ' active after close', function (t) {
+    t.plan(5)
+
+    const r = createNanoresource({
+      close (cb) {
+        t.notOk(r.active(), 'cannot be active in close')
+        setImmediate(cb)
+      }
+    })
+
+    t.ok(r.active(), 'can be active')
+    r.open()
+    t.ok(r.active(), 'can be active')
+    r.close(() => t.notOk(r.active(), 'still cannot be active'))
+    t.notOk(r.active(), 'cannot be active cause close was call')
+
+    r.inactive()
+    r.inactive()
+  })
+
+  tape(title + ' reopen', function (t) {
+    t.plan(2 * 2 + 2 + 3 * 2 + 3)
+
+    let opened = false
+    let closed = false
+
+    const r = createNanoresource({
+      reopen: true,
+      open (cb) {
+        t.notOk(closed, 'not closed in open')
+        t.notOk(opened, 'only open once')
+        opened = true
+        cb(null)
+      },
+      close (cb) {
+        t.ok(opened, 'opened when closing')
+        t.notOk(closed, 'only close once')
+        closed = true
+        setImmediate(() => {
+          r.open(onopen)
+          cb(null)
+        })
+      }
+    })
+
+    r.open(onopen)
+
+    r.close(onclose)
+
+    function onopen (err) {
+      t.error(err, 'no error')
+      t.ok(r.opened, 'was opened')
+      t.ok(opened, 'open ran')
+    }
+
+    function onclose (err) {
+      t.error(err, 'no error')
+      t.ok(r.closed, 'was closed')
+      t.ok(closed, 'close ran')
+      opened = false
+      closed = false
+    }
+  })
+}
+
+test('nanoresource', nanoresource)
+test('nanoresource/emitter', nanoresourceEmitter)


### PR DESCRIPTION
This PR does:
- Refactor `nanoresource` to ES6 clases and following same concepts than hyperswarm classes.
- Refactor `nanoresource/emitter` to remove the need of having duplicate the codebase of nanoresource.
- Add testing for `nanoresource/emitter`.
- Add `reopen` feature.

`reopen` provides similar behavior of how level-up allows to reopen a database.

Personal opinion, in case that this PR can be merged I think should be good to release a major version.